### PR TITLE
with_opacity() obsolete

### DIFF
--- a/profileApp/main.py
+++ b/profileApp/main.py
@@ -56,13 +56,11 @@ class ProfilePage(ft.View):
                             width=128,
                             height=128,
                             shape=ft.BoxShape("circle"),
-                            # Define image for profile picture
-                            image_src="/profile.jpg",
-                            image_fit="cover",
+                            content=ft.Image(src="/profile.jpg", fit="cover"),
                             shadow=ft.BoxShadow(
                                 spread_radius=6,
                                 blur_radius=20,
-                                color=ft.colors.with_opacity(0.71, "black"),
+                                color=ft.Colors.with_opacity(0.71, "black"),
                             ),
                         ),
                         ft.Divider(height=10, color="transparent"),


### PR DESCRIPTION
image_src is not a valid argument to ft.Container, so you must replace it with an ft.Image inside the Container, and also, the with_opacity() function is deprecated, so you must use ft.Colors.with_opacity() or define the color in rgba() format. this does not give a console error when you run
![1](https://github.com/user-attachments/assets/b64f3e91-5a9b-481c-85c5-f1f50c56f6ec)


ft.Container(
    bgcolor="white10",
    width=128,
    height=128,
    shape=ft.BoxShape("circle"),
    content=ft.Image(src="/profile.jpg", fit="cover"),
    shadow=ft.BoxShadow(
        spread_radius=6,
        blur_radius=20,
        color=ft.colors.with_opacity(0.71, "black"),
    ),
),
